### PR TITLE
avoid some php deprecation warnings by ensuring integer values

### DIFF
--- a/src/phplot.php
+++ b/src/phplot.php
@@ -2115,7 +2115,7 @@ class phplot
             $ry = $qy + $r10 * $width_factor + $r11 * $font_height;
 
             // Finally, draw the text:
-            ImageTTFText($this->img, $font_size, $angle, $rx, $ry, $color, $font_file, $lines[$i]);
+            ImageTTFText($this->img, $font_size, $angle, (int)$rx, (int)$ry, (int)$color, $font_file, $lines[$i]);
 
             // Step to position of next line.
             // This is a rotation of (x=0,y=height+line_spacing) by $angle:
@@ -7858,7 +7858,7 @@ class phplot
         }
 
         // Draw the bar
-        ImageFilledRectangle($this->img, $x1, $y1, $x2, $y2, $data_color);
+        ImageFilledRectangle($this->img, (int)$x1, (int)$y1, (int)$x2, (int)$y2, (int)$data_color);
 
         // Draw a shade, if shading is on.
         if (isset($shade_color)) {


### PR DESCRIPTION
Hi there,

I wanted to let you know that [phplot version v8.0.0.1](https://github.com/PHPlot/phplot/releases/tag/v8.0.0.1) with PHP version 8.1.x leads to *PHP Deprecated* warnings due to implicit conversion of float values to integer values, i.e.

> PHP Deprecated:  Implicit conversion from float 80.5 to int loses precision in vendor/phplot/phplot/src/phplot.php on line 2118
> PHP Deprecated:  Implicit conversion from float 138.43333333333334 to int loses precision in vendor/phplot/phplot/src/phplot.php on line 7861

I fixed at least this two with the PR, there is possible other places to fix in the future.

What I did: I just made sure to cast the values to integer when passing as method / constructor parameter. This does not change behaviour as the values are casted to integer from float by *implicit conversion* anyway, which leads to the issue using PHP 8.1.

Please let me know if this PR works for you and do not hesitate to get in touch in case you need something.

Thanks,
Benjamin