### PR TITLE
exclude phpstorm ide directory from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /vendor
 /composer.lock
+/.idea
 /phpunit.xml
 /.phpunit.result.cache
 /phpcs.xml


### PR DESCRIPTION
Hi there, 

on my work to #2 I came up with PHPStorm files shown in the git client. To avoid this I created this PR, which basically just makes sure to exclude PHPStorm's meta directory *.idea* from version control using the `.gitignore` file.

Kind regards,
Benjamin