### PR TITLE
add .gitattributes file to make the package distributed via composer leaner

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.githooks/ export-ignore
+/.github/ export-ignore
+/phplotdocs/ export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore


### PR DESCRIPTION
The .gitattributes file can be used to tell git, and thereby github composer, to skip some files when building the release tarball.

I think this is especially useful in this case, as it makes no sense to ship to end users the sources of the pdf manual, which btw also include a symlink to the main php source file which might trip the unwary developer 