### PR TITLE
remove $Id$ tags as we are not using svn anymore; trim trailing spaces

### DIFF
--- a/phplotdocs/ChangeLog
+++ b/phplotdocs/ChangeLog
@@ -241,8 +241,8 @@ manual, which only contains summaries of changes.
     * Merged /branches/Rel6 changes back into trunk. Changes recorded below
       with "(/branches/Rel6)" were made on the branch. Note: Subversion
       change history for those changes is only available by looking at
-      revision 1558 on the branch, for example: 
-         svn log ^/branches/Rel6/phplotdocs/concepts.xml@1558 
+      revision 1558 on the branch, for example:
+         svn log ^/branches/Rel6/phplotdocs/concepts.xml@1558
       The /branches/Rel6 tree has not been deleted, but may be in the future
       (as recommended in Subversion documentation).
 
@@ -1100,7 +1100,7 @@ manual, which only contains summaries of changes.
         Clarify or fix use of "axis" when describing ticks and labels.  These
         might not actually be on the axis lines.
    * reference.xml: Specify new defaults in SetXAxisPosition, SetYAxisPosition.
-        Also corrected text on axis position in SetYTickLabelPos, SetYTickPos, 
+        Also corrected text on axis position in SetYTickLabelPos, SetYTickPos,
         SetPlotBorderType, and others.
 
 
@@ -1483,7 +1483,7 @@ manual, which only contains summaries of changes.
 2009-06-13
    * main.xml: Update license information. PHPlot is now under the LGPL.
    * reference.xml: Add notes to SetRGBArray() about finding the rgb.inc.php
-       file (related to a recent bug fix), about the default color map, and 
+       file (related to a recent bug fix), about the default color map, and
        how to avoid invalid color errors with custom color maps.
 
 2009-05-25
@@ -1610,7 +1610,7 @@ manual, which only contains summaries of changes.
      area edges.
      Also cross-reference back from SetXDataLabelPos, and explain what happens
      to the data label lines when a plot has multiple data sets.
- 
+
 2007-09-30
    * New Part III - PHPlot Developer's Guide. This includes two layout figures
      (overall plot, and legend), and a list of internal functions. This
@@ -1729,5 +1729,3 @@ manual, which only contains summaries of changes.
   * Fixed typos in examples, concepts/datatypes, example/pie1
 
 2005-02-06 Released draft manual tagged REL20050206 dated 2005-02-06
-
-$Id$

--- a/phplotdocs/Makefile
+++ b/phplotdocs/Makefile
@@ -1,4 +1,4 @@
-# $Id$
+
 # Makefile for PHPlot Programmer's Reference Manual (Docbook-xml version)
 # This uses xsltproc to generate HTML output.
 # And it uses xsltproc, xmllint, and Apache fop for PDF output.
@@ -361,7 +361,7 @@ examples/pielabeltype5.png: examples/pielabeltype5.php examples/pielabeltypedata
 
 # === For building the variable list documentation ===
 
-$(VARIABLE_LIST): variables.list gen.vardoc 
+$(VARIABLE_LIST): variables.list gen.vardoc
 	$(PHP) gen.vardoc < variables.list > $(VARIABLE_LIST)
 
 # ===

--- a/phplotdocs/gen.vardoc
+++ b/phplotdocs/gen.vardoc
@@ -1,6 +1,5 @@
 <?php
 /*
-$Id$
 
 Generate documentation for PHPlot variables
    Copyright 2015 ljb - This is part of the PHPlot Reference Manual Source

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,4 @@
 # Makefile for release of PHPLot
-# $Id$
 
 # Project name:
 PROJ=phplot
@@ -72,4 +71,3 @@ release:
 phpdoc:
 	mkdir -p $(PHPDOCDIR)
 	$(PHP) $(PHPDOCUMENTOR) --template=$(TEMPLATE) -f phplot.php -t $(PHPDOCDIR)
-

--- a/src/contrib/color_range.example.php
+++ b/src/contrib/color_range.example.php
@@ -1,6 +1,5 @@
 <?php
 # PHPlot / contrib / color_range : Example
-# $Id$
 # This is a bar chart with a color gradient for the bars in each group.
 
 require_once 'phplot.php';

--- a/src/contrib/color_range.php
+++ b/src/contrib/color_range.php
@@ -1,7 +1,6 @@
 <?php
 /*
    PHPlot / contrib / color_range
-   $Id$
    PHPlot contrib code - public domain - no copyright - use as you wish
 
    Original contribution from: Josep Sanz <josep dot sans at w3 dot es>

--- a/src/contrib/color_range.test1.php
+++ b/src/contrib/color_range.test1.php
@@ -1,6 +1,5 @@
 <?php
 # PHPlot / contrib / color_range : Test 1, make a picture
-# $Id$
 # This creates a PNG file on output with a color gradient.
 
 require_once 'color_range.php';

--- a/src/contrib/color_range.test2.php
+++ b/src/contrib/color_range.test2.php
@@ -1,7 +1,6 @@
 <?php
 /*
   PHPlot / contrib / color_range : Unit tests
-  $Id$
 
   Tests color.range.php functions:
       color_range($color_a, $color_b, $n_steps)

--- a/src/contrib/data_table.example1.php
+++ b/src/contrib/data_table.example1.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # phplot / contrib / data_table example 1:  Stand-alone data tables
 # This example does not use PHPlot. Output is a PNG file with multiple
 # data tables, with varying parameters.

--- a/src/contrib/data_table.example2.php
+++ b/src/contrib/data_table.example2.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # phplot / contrib / data_table example 2: Line plot with data table on the side
 require_once 'phplot.php';
 require_once 'data_table.php';

--- a/src/contrib/data_table.example3.php
+++ b/src/contrib/data_table.example3.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # phplot / contrib / data_table example 3:  Pie chart with data table
 require_once 'phplot.php';
 require_once 'data_table.php';

--- a/src/contrib/data_table.php
+++ b/src/contrib/data_table.php
@@ -1,5 +1,5 @@
 <?php
-/* $Id$
+/*
 phplot / contrib / data_table.php: Draw a table of data values
 
      Copyright (c) 2011, lbayuk -at- users.sourceforge.net
@@ -161,7 +161,7 @@ function draw_data_table($img, $settings)
     // factors are ignored, since each column will be as wide as needed.
     if (empty($o_width)) {
         $o_width = 0;
-        $col = 0; // Index to unskipped columns 
+        $col = 0; // Index to unskipped columns
         for ($i = 0; $i < $n_data_cols; $i++) { // Index to all columns
             if (is_null($o_headers[$i])) continue; // Skip column
             // Find the longest string in this column, post-formatting.
@@ -211,9 +211,9 @@ function draw_data_table($img, $settings)
         if ($row == 0) $cells = $o_headers; // Header row
         else $cells = $o_data[$row - 1]; // -1 accounts for header row.
 
-        $col = 0; // Index to unskipped columns 
+        $col = 0; // Index to unskipped columns
         for ($i = 0; $i < $n_data_cols; $i++) { // Index to all columns
-           
+
             if (is_null($o_headers[$i])) continue; // NULL header => skip column
 
             if (($cell = $cells[$i]) !== '') { // Empty cell?

--- a/src/contrib/prune_labels.example.php
+++ b/src/contrib/prune_labels.example.php
@@ -1,6 +1,5 @@
 <?php
 # PHPlot / contrib / prune_labels : Example
-# $Id$
 # This produces 250 data points with date-formatted labels, and sets
 # a max of 20 labels to display.
 

--- a/src/contrib/prune_labels.php
+++ b/src/contrib/prune_labels.php
@@ -1,7 +1,6 @@
 <?php
 /*
    PHPlot / contrib / prune_labels
-   $Id$
    PHPlot contrib code - public domain - no copyright - use as you wish
 
 Reduce the number of data labels along the X axis,  when the density is too

--- a/src/contrib/prune_labels.test.php
+++ b/src/contrib/prune_labels.test.php
@@ -1,6 +1,5 @@
 <?php
 # PHPlot / contrib / prune_labels : Test
-# $Id$
 # Test driver for contrib / prune_labels
 
 require_once 'prune_labels.php';

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,4 @@
 # Makefile for PHPlot Test Suite
-# $Id$
 # This Makefile is used to make a zip file release of the test suite.
 
 # Staging area, zip file base name, and directory when unpacked:

--- a/test/areaborders04.php
+++ b/test/areaborders04.php
@@ -1,9 +1,7 @@
 <?php
-# $Id$
 # PHPlot test: areas+borders - area, unordered data
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(
   'mixed_data' => TRUE,
   );
 require 'areaborders00.php';
-

--- a/test/areaborders24.php
+++ b/test/areaborders24.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: areas+borders - squaredarea, unordered data
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(
@@ -7,4 +6,3 @@ $tp = array(
   'mixed_data' => TRUE,
   );
 require 'areaborders00.php';
-

--- a/test/automargin1c.php
+++ b/test/automargin1c.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing phplot - Automatic margin calculation - 1c
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/bardir1.php
+++ b/test/bardir1.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Bar chart bar direction test - case all Y>=0
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/bardir6.php
+++ b/test/bardir6.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Bar chart bar direction test - thinbarline case all Y>=0
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/bars-datalabel.php
+++ b/test/bars-datalabel.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing phplot - Bars, with new (post-5.0rc2) datalabel feature
 # This is a parameterized test. Other scripts can set $tp and then include
 # this script. The parameters are shown in the defaults array below:

--- a/test/borders08.php
+++ b/test/borders08.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Plot and image borders - case 08
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/boxplot-missing.php
+++ b/test/boxplot-missing.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Box plot, missing values
 require_once 'phplot.php';
 

--- a/test/boxplot2.php
+++ b/test/boxplot2.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Box plot with data variations
 # See the script named below for details
 #   Colors:  (box, belt, outliers, whiskers & Ts)

--- a/test/colorcall06a.php
+++ b/test/colorcall06a.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Color callback - thinbarline plot with color callback
 # See the script named below for details.
 $plot_type = 'thinbarline';

--- a/test/colorcall11.php
+++ b/test/colorcall11.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Color callback - data-data-error linepoints plot, baseline
 # See the script named below for details.
 $plot_type = 'linepoints';

--- a/test/colorcallback-gradient.php
+++ b/test/colorcallback-gradient.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot Example: Creative use of data colors
 require_once 'phplot.php';
 

--- a/test/coloritems.php
+++ b/test/coloritems.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Coloring various items
 require_once 'phplot.php';
 

--- a/test/datalabellines8.php
+++ b/test/datalabellines8.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Data Label Lines - 8
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/date1.php
+++ b/test/date1.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing phplot - Date X axis labels
 require_once 'phplot.php';
 

--- a/test/dde-missy2.php
+++ b/test/dde-missy2.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Missing Y values in data-data-error plots: case 2
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/dde-missy7.php
+++ b/test/dde-missy7.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Missing Y values in data-data-error plots: case 7
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/defaultfont3b.php
+++ b/test/defaultfont3b.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing phplot - Default TT font (3b): Set font with file basename only
 require_once 'phplot.php';
 require_once 'config.php'; // TTF setup

--- a/test/dlexformat1a.php
+++ b/test/dlexformat1a.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Data label extended custom formatting - 1a, points
 # This is a parameterized test. See the script named at the bottom for details.
 $plot_type = 'points';

--- a/test/dlexformat2b.php
+++ b/test/dlexformat2b.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Data label extended custom formatting - 2b, bubbles
 # This is a parameterized test. See the script named at the bottom for details.
 $plot_type = 'bubbles';

--- a/test/dlexformat2g.php
+++ b/test/dlexformat2g.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Data label extended custom formatting - 2g, thinbarline (vert)
 # This is a parameterized test. See the script named at the bottom for details.
 $plot_type = 'thinbarline';

--- a/test/drawtext-ttf_090d_5l.php
+++ b/test/drawtext-ttf_090d_5l.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Unit test: PHPlot DrawText function - TrueType at 90 degrees, multiple lines
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/drawtext-ttf_180d_5l.php
+++ b/test/drawtext-ttf_180d_5l.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Unit test: PHPlot DrawText function - TrueType at 180 degrees, multiple lines
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/drawtext-ttf_270d_5l.php
+++ b/test/drawtext-ttf_270d_5l.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Unit test: PHPlot DrawText function - TrueType at 270 degrees, multiple lines
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/empty-nocols-lpe.php
+++ b/test/empty-nocols-lpe.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test - empty plot with no Y values at all, linepoints error plot
 # This is a parameterized test. See the script named at the bottom for details.
 $plot_type = 'linepoints';

--- a/test/empty-nocols-tb.php
+++ b/test/empty-nocols-tb.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test - empty plot with no Y values at all, thinbarline
 # This is a parameterized test. See the script named at the bottom for details.
 $plot_type = 'thinbarline';

--- a/test/encodeimg1.php
+++ b/test/encodeimg1.php
@@ -1,8 +1,7 @@
 <?php
-# $Id$
 # PHPlot test: Data URL (RFC2397)
 # Note: To test Data URL right, you need to make an HTML file and then view
-# it in a browser. But that doesn't fit well with the way the PHPlot Test Suite 
+# it in a browser. But that doesn't fit well with the way the PHPlot Test Suite
 # generates and validates results. Instead, this script will save the
 # HTML output to a fixed name file, and also do some simple regexp matching
 # on it.

--- a/test/error-SetPlotAreaWorld.php
+++ b/test/error-SetPlotAreaWorld.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing PHPlot - Bad data range with SetPlotAreaWorld - baseline/master
 # Other scripts set $spaw and $subtitle and then include this script.
 require 'phplot.php';

--- a/test/error-argument3.php
+++ b/test/error-argument3.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot error test - argument error with returning handler, redo the graph.
 require 'esupport.php';
 set_error_handler('test_catch_return');

--- a/test/error-ttfpath5.php
+++ b/test/error-ttfpath5.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Error test - bad TTF font. See error-ttfpath.php for details.
 $case = 5;
 require 'error-ttfpath.php';

--- a/test/ex-pielabeltype2.php
+++ b/test/ex-pielabeltype2.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot Example: Pie Chart Label Types - Labels from data array
 # This requires PHPlot >= 5.6.0
 require_once 'phplot.php';

--- a/test/fractionticks.php
+++ b/test/fractionticks.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Fractional tick labels
 # This uses binary auto-tick mode on the Y axis, with a small Y range,
 # and a custom label formatting function to display the labels as

--- a/test/horizplotyaxis3.php
+++ b/test/horizplotyaxis3.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Horizontal plot Y axis default - Bars, data <0 and >0
 require_once 'phplot.php';
 $data = array(

--- a/test/imagemap_html-hb.php
+++ b/test/imagemap_html-hb.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot Test - Image map and embedded image - horizontal bars
 $out_name = basename(__FILE__, '.php');
 $plot_type = 'bars';

--- a/test/imagemap_trace-hsb.php
+++ b/test/imagemap_trace-hsb.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Horiz bar chart, with image map area outlines shown.
 # See the script named below for details
 $plot_type = 'stackedbars';

--- a/test/imagemap_trace-o.php
+++ b/test/imagemap_trace-o.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: OHLC plot, with image map area outlines shown.
 # See the script named below for details
 $plot_type = 'ohlc';

--- a/test/imagemap_trace-sb.php
+++ b/test/imagemap_trace-sb.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Stackedbar chart, with image map area outlines shown.
 # See the script named below for details
 $plot_type = 'stackedbars';

--- a/test/imagemap_unit-pi-dd.php
+++ b/test/imagemap_unit-pi-dd.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot Unit test: Image map with pie chart, data-data case
 # See the script named below for details
 $data_type = 'data-data';

--- a/test/labelprec3.php
+++ b/test/labelprec3.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: SetPrecisionY() vs pie chart, override
 # See the script included below for details.
 $override = TRUE;

--- a/test/labelvars02.php
+++ b/test/labelvars02.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing phplot - tick/data label variant formatting - case 02
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/legend_ttf-2.php
+++ b/test/legend_ttf-2.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # SetLegendStyle - TrueTrype, right aligned text
 $tp = array(
   'suffix' => ' (TrueType, text=right)',   # Title part 2
@@ -8,6 +7,6 @@ $tp = array(
   'textalign' => 'right', # Legend Text Align. If NULL, don't call SetLegendStyle
   'text' => array(          # Legend array text, NULL to use built-in data.
      'Line 1 text', 'oxzz', 'Line 3', 'Ppq 4', 'Line 5'),
-      
+
   );
 require 'legend_--.php';

--- a/test/legendorder1.php
+++ b/test/legendorder1.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Legend order reversal, master / stackedbars baseline
 #  Parameters can be set by a calling test:
 #    $reverse = True or False

--- a/test/lines-n1.php
+++ b/test/lines-n1.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing phplot - "N" Lines with parameters - 1
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/lines3.php
+++ b/test/lines3.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing phplot - Lines
 require_once 'phplot.php';
 

--- a/test/long-labels03.php
+++ b/test/long-labels03.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # X label size and angle test - GD font 3
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/missingh_b.php
+++ b/test/missingh_b.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Horizontal Plots with missing data - plot type bars
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/multidefault-axis2.php
+++ b/test/multidefault-axis2.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing PHPlot - Multi-plot with axis change - case 2
 # See the script named below for details.
 $case = 2;

--- a/test/multiline-label3.php
+++ b/test/multiline-label3.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Multi-line data labels, TTF at 90 deg
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/noaxis.php
+++ b/test/noaxis.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing phplot - Suppress axis lines - baseline/master
 require_once 'phplot.php';
 # Test case is selected by $case.

--- a/test/nodata1.php
+++ b/test/nodata1.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot error test - Charts with bad data array, case 1
 $case = 1;
 require_once 'nodata.php';

--- a/test/ohlc1b1.php
+++ b/test/ohlc1b1.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing phplot - Basic OHLC. Variable number of points. Testing widths.
 $n = 35;
 $plot_type = 'ohlc';

--- a/test/ohlc1b6.php
+++ b/test/ohlc1b6.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing phplot - Basic OHLC. Variable number of points. Testing widths.
 $n = 50;
 $plot_type = 'ohlc';

--- a/test/ohlcskip.php
+++ b/test/ohlcskip.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # OHLC Plot with skipped values
 # Set $plottype to 'ohlc' (default), 'candlesticks', or 'candlesticks2',
 # Set $datatype to 'text-data' (default) or 'data-data',

--- a/test/pie-zero.php
+++ b/test/pie-zero.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Bug 1827263, spoiled chart if close to zero - case 1
 require_once 'phplot.php';
 

--- a/test/pie1.php
+++ b/test/pie1.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot Example: Pie/text-data-single
 require_once 'phplot.php';
 

--- a/test/pieautosize3.php
+++ b/test/pieautosize3.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test - Pie Chart Sizing - auto vs manual - case 3
 # This is a parameterized test. See the script named at the bottom for details.
 $pie_autosize = FALSE;

--- a/test/piebcol5.php
+++ b/test/piebcol5.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot Test: Pie border color and control, case 5
 # See the script named below for details
 $border_on = True;

--- a/test/piesize2e.php
+++ b/test/piesize2e.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test - Pie Chart Sizing and Label Variations - label scale position (e)
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/piesize3f.php
+++ b/test/piesize3f.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test - Pie Chart Sizing and Label Variations - Pie/image size (f)
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/piesize5a.php
+++ b/test/piesize5a.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test - Pie Chart Sizing and Label Variations - Size/Label Position (a)
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/piesize5f.php
+++ b/test/piesize5f.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test - Pie Chart Sizing and Label Variations - Size/Label Position (f)
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/piesize8b.php
+++ b/test/piesize8b.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test - Pie Chart Sizing and Label Variations - Custom multi-part label
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/pmarg1.php
+++ b/test/pmarg1.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Partial margin specification with SetMarginsPixels - 1
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/range-auto5t0.php
+++ b/test/range-auto5t0.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Plot auto-range test
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/range-auto7dec1.php
+++ b/test/range-auto7dec1.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Plot auto-range test
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/range-auto8mt4.php
+++ b/test/range-auto8mt4.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Plot auto-range test
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/range-auto8mt9.php
+++ b/test/range-auto8mt9.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Plot auto-range test
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/range-datex2a.php
+++ b/test/range-datex2a.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Date/time range on X axis
 #            H  M  S  mo da yr
 $t1 = mktime(0, 0, 0, 8, 1, 2010);

--- a/test/setlegrelm2.php
+++ b/test/setlegrelm2.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing legend relative position - margin adjustment case 2
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/setlegrelp3.php
+++ b/test/setlegrelp3.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing legend relative position - case plot-3
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/setlegrelw4.php
+++ b/test/setlegrelw4.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing legend relative position - case world-4
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/squarea2a.php
+++ b/test/squarea2a.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Squared and Squared Area (2a)
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/squarea2f.php
+++ b/test/squarea2f.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Squared and Squared Area (2f)
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/squared1.php
+++ b/test/squared1.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot Example: squared plot
 require_once 'phplot.php';
 

--- a/test/stackedbarlabel5.php
+++ b/test/stackedbarlabel5.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Test: stackedbars with labels, moved X axis, set YMIN
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/testclass.php
+++ b/test/testclass.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test support - superclass
 # This script defines 2 superclasses of PHPlot which are for testing.
 #

--- a/test/tickcount.php
+++ b/test/tickcount.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing phplot - Wrong ticks on X and Y
 # This is a parameterized test. Other scripts can set $tp and then include
 # this script. The parameters are shown in the defaults array below:

--- a/test/tickset2.php
+++ b/test/tickset2.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing phplot - Setting tick increment and/or number of ticks
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/tickset7.php
+++ b/test/tickset7.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Testing phplot - Setting tick increment and/or number of ticks
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/tunebars1bu.php
+++ b/test/tunebars1bu.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Bar chart tuning variables - full width unshaded bars
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/tunebars1ss.php
+++ b/test/tunebars1ss.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Bar chart tuning variables - full width shaded stackedbars
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/tunebars2bu.php
+++ b/test/tunebars2bu.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # PHPlot test: Bar chart tuning variables - spread out unshaded bars
 # This is a parameterized test. See the script named at the bottom for details.
 $tp = array(

--- a/test/u.FindDataLimits.php
+++ b/test/u.FindDataLimits.php
@@ -1,5 +1,4 @@
 <?php
-# $Id$
 # Unit tests for FindDataLimits, related to bug reports: 2786354, 2786350
 # This doesn't output a graph. It checks the behavior of FindDataLimits
 # for various data sets.
@@ -112,14 +111,14 @@ test('data-data baseline', 'data-data', 'lines', array(
 
 # Other simple cases:
 test('text-data.2', 'text-data', 'lines', array(
-         array('a', 1, 100, 100, -200), 
+         array('a', 1, 100, 100, -200),
          array('b', 2, 100, 200,  300)),
      array(0.0, 2.0, -200.0, 300.0));
 
 test('data-data.3', 'data-data', 'lines', array(
-         array('a', 1, 100, 100, -200), 
-         array('b', 2, 100, 200,  300), 
-         array('c', 5, 400, 200,  0), 
+         array('a', 1, 100, 100, -200),
+         array('b', 2, 100, 200,  300),
+         array('c', 5, 400, 200,  0),
          array('d', 8, 100, 800, 30)),
      array(1.0, 8.0, -200.0, 800.0));
 
@@ -131,8 +130,8 @@ test('text-data.4', 'text-data', 'lines', array(
 
 # Missing data point cases
 test('Missing Y data point, text-data', 'text-data', 'lines', array(
-         array('a', 100, 100, 50), 
-         array('b', 100, 200, ''), 
+         array('a', 100, 100, 50),
+         array('b', 100, 200, ''),
          array('c', 100, '',  300)),
      array(0.0, 3.0, 50.0, 300.0));
 


### PR DESCRIPTION
`$Id$` tags in files are a relic of using subversion (or cvs/rcs?) and not used any more in the git world